### PR TITLE
Fix invisible entites after convering from qwd

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -153,6 +153,7 @@ typedef struct
 	int			playernum;
 	int			prevnum[MAX_CLIENTS];
 	int			validsequence;
+	int			delta_sequence;
 	qbool		spectator;
 	int			framecount;
 	float		latency;

--- a/src/dem_parse.c
+++ b/src/dem_parse.c
@@ -790,6 +790,7 @@ void FlushEntityPacket (void)
 	memset (&olde, 0, sizeof(olde));
 
 	//world.validsequence = 0;		// can't render a frame
+	from->delta_sequence = 0;
 	from->frames[from->netchan.incoming_sequence&UPDATE_MASK].invalid = true;
 
 	// read it all, but ignore it
@@ -857,7 +858,7 @@ void Dem_ParsePacketEntities (qbool delta)
 			}
 		}
 
-		from->validsequence = from->netchan.incoming_sequence;
+		from->delta_sequence = from->validsequence = from->netchan.incoming_sequence;
 		oldp = &from->frames[oldpacket&UPDATE_MASK].packet_entities;
 		full = false;
 	}
@@ -865,7 +866,7 @@ void Dem_ParsePacketEntities (qbool delta)
 	{	// this is a full update that we can start delta compressing from now
 		oldp = &dummy;
 		dummy.num_entities = 0;
-		from->validsequence = from->netchan.incoming_sequence;
+		from->delta_sequence = from->validsequence = from->netchan.incoming_sequence;
 		full = true;
 	}
 
@@ -982,6 +983,7 @@ void Dem_ParsePacketEntities (qbool delta)
 		{	// delta from previous
 			if (full)
 			{
+				from->delta_sequence = 0;
 				//world.validsequence = 0;
 				//Con_Printf ("WARNING: delta on full update");
 			}

--- a/src/main.c
+++ b/src/main.c
@@ -448,6 +448,7 @@ nextdemomessage:
 		pcmd->upmove      = LittleShort(pcmd->upmove);
 		from->frames[i].senttime = demotime;
 		from->frames[i].receivedtime = -1;		// we haven't gotten a reply yet
+		from->frames[i].delta_sequence = from->delta_sequence;
 		from->netchan.outgoing_sequence++;
 		from->frames[i].playerstate[from->playernum].command = *pcmd;
 		for (j=0 ; j<3 ; j++)


### PR DESCRIPTION
ezquake now by default saves qwd demos with delta compression,
previously it did not do that. qwdtools does not really supported delta
compression so after convering you had broken (invisible entities) mvd demo.
So this commit seems to fix it.

Follow up for #12.