### PR TITLE
fix: correct arguments passed to qizmo

### DIFF
--- a/src/qwz.c
+++ b/src/qwz.c
@@ -106,7 +106,7 @@ qbool OpenQWZ (char *files)
 			snprintf(curdir, sizeof(curdir), "%s/%s", currentDir, qizmoDir);
 	}
 
-	strlcpy (cmdline, va("%s/" QIZMO_BIN "-D %s", curdir,
+	strlcpy (cmdline, va("%s/" QIZMO_BIN " -D %s", curdir,
 	                     files), sizeof(cmdline));
 
 #ifdef _WIN32


### PR DESCRIPTION
**issue**
there is a space missing between the qizmo binary and the `-D` (decompress) argument.
https://github.com/QW-Group/qwdtools/blob/8af104b9d95f5fcd2dd7fed7a96d70f653778158/src/qwz.c#L109

**before fix**
```
./qwdtools -noini -qd . __dag__sr__vs_pnc_dm2.qwz
QWDtools version 0.34 (c) 2001-2003 Bartlomiej Rychtarski
Unix port by David (hexum) Balcom and VVD, 2004-2007
Part of the MVDSV project: https://github.com/QW-Group/qwdtool

decompressing qwz file(s)...
sh: 1: /home/vikpe/dev/test/qizmo-D: not found
Couldn't execute /home/vikpe/dev/test/qizmo
Couldn't decompress qwz file(s)
```

**after fix**
```
./qwdtools -noini -qd . __dag__sr__vs_pnc_dm2.qwz
QWDtools version 0.34 (c) 2001-2003 Bartlomiej Rychtarski
Unix port by David (hexum) Balcom and VVD, 2004-2007
Part of the MVDSV project: https://github.com/QW-Group/qwdtool

decompressing qwz file(s)...

QW Qizmo v2.91 Copyright 1998 Juha Kujala and Ilkka Rajala
For non-commercial use only. No warranty. Use at your own risk.
http://qizmo.sci.fi

Initializing...
Decompressing __dag__sr__vs_pnc_dm2.qwz -> __dag__sr__vs_pnc_dm2.qwd

decompressing finished
```
